### PR TITLE
Disallow prototype path override - checking magic attributes

### DIFF
--- a/ini_parser.js
+++ b/ini_parser.js
@@ -4,6 +4,26 @@ var sectionNameRegex = /\[(.*)]$/;
 var comments = [";", "#"]
 var delimiter = ["=", ":"]
 
+var ILLEGAL_KEYS = ['__proto__']
+
+function isIllegalKey (key) {
+  return ILLEGAL_KEYS.indexOf(key) !== -1
+}
+
+function isProtoPath (path) {
+  return Array.isArray(path)
+    ? path.some(isIllegalKey)
+    : typeof path === 'string'
+      ? isIllegalKey(path)
+      : false
+}
+
+function disallowProtoPath (path) {
+  if (isProtoPath(path)) {
+    throw new Error('Unsafe path encountered: ' + path)
+  }
+}
+
 function IniParser(path, encoding) {
     this.path = path
     this.encoding = encoding || "UTF8"
@@ -39,6 +59,7 @@ function IniParser(path, encoding) {
             var matchArr = line.match(sectionNameRegex)
             if (line.startsWith('[') && matchArr != null) {
                 curSection = matchArr[1]
+                disallowProtoPath(curSection)
                 if (!(curSection in this.configs)) {
                     this.configs[curSection] = {}
                     // contents.push(rowContent('section', curSection, '', curSection))


### PR DESCRIPTION
### 📊 Metadata *

`iniparserjs ` is vulnerable to Prototype Pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-iniparserjs/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```
// poc.js
var path = require("path")
var IniParser = require("iniparserjs")
console.log('Before:', {}.polluted);
var config = new IniParser(path.join(__dirname, "payload.ini"), "UTF8")
var sections = config.sections()
console.log('After:', {}.polluted);
```

```
//payload.ini
[__proto__]
polluted = "Yes! Its Polluted";
```

2. Execute the following commands in terminal:

```
npm i iniparserjs # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:
```

Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106950320-3d66e780-6754-11eb-8882-2f801046c56d.png)

After:
![image](https://user-images.githubusercontent.com/64132745/106950233-21fbdc80-6754-11eb-9b5d-758cee825b33.png)


### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1845
